### PR TITLE
add colors for link and unlink logs

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -58,8 +58,8 @@ pub fn unlink(symlink_target_path: &Path) -> Result<(), std::io::Error> {
 		fs::remove_dir_all(symlink_target_path)?;
 	}
 
-	let pretty_path = prettify_path(symlink_target_path);
-	println!("✅ Deleted: {pretty_path}");
+	let pretty_symlink_target_path = prettify_path(symlink_target_path);
+	println!("✅ Deleted: {}", Red.paint(pretty_symlink_target_path));
 
 	Ok(())
 }


### PR DESCRIPTION
closes #1

- link 
<img width="787" height="313" alt="image" src="https://github.com/user-attachments/assets/bba4273d-c655-45e1-8bc9-728c5b395c30" />

- unlink
<img width="481" height="320" alt="image" src="https://github.com/user-attachments/assets/42686e0b-c7b7-4f2b-8039-adc2fffc9bb4" />

